### PR TITLE
Fix contact details horizontal padding

### DIFF
--- a/src/form/render/inputs/contactDetails.tsx
+++ b/src/form/render/inputs/contactDetails.tsx
@@ -15,7 +15,7 @@ export function _renderInputContactDetails(context: _RenderingContext, enquiryCo
   }
 
   return [
-    <h2>{enquiryContent.title}</h2>,
+    <h2 style={_renderHorizontalPadding(context.padding)}>{enquiryContent.title}</h2>,
     <div class="_q-contact-details" style={_renderHorizontalPadding(context.padding)}>
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
         <path


### PR DESCRIPTION
Adds horizontal padding to the contact details title to fix alignment on mobile.

This addresses a confirmed bug where the contact details title lacked proper horizontal padding, leading to misalignment, especially on mobile devices.

---
[Slack Thread](https://nightshifthabits.slack.com/archives/C084A2DDF7Z/p1755526708940069?thread_ts=1755526708.940069&cid=C084A2DDF7Z)

<a href="https://cursor.com/background-agent?bcId=bc-6cab07b4-9f80-4e5e-8fac-005eaa025e82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cab07b4-9f80-4e5e-8fac-005eaa025e82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

